### PR TITLE
Add support for reactive power, KVARH metrics, and runtime sensors

### DIFF
--- a/custom_components/iammeter_modbus/__init__.py
+++ b/custom_components/iammeter_modbus/__init__.py
@@ -337,28 +337,28 @@ class IammeterModbusHub:
             self.data["reactive_power_a"] = reactive_power_a
 
             inductive_kvarh_a = u32(40)          # 40~41
-            self.data["inductive_kvarh_a"] = round(inductive_kvarh_a / 800, 3)
+            self.data["inductive_kvarh_a"] = round(inductive_kvarh_a / 1000, 3)
 
             capacitive_kvarh_a = u32(42)         # 42~43
-            self.data["capacitive_kvarh_a"] = round(capacitive_kvarh_a / 800, 3)
+            self.data["capacitive_kvarh_a"] = round(capacitive_kvarh_a / 1000, 3)
 
             reactive_power_b = s32(44)           # 44~45
             self.data["reactive_power_b"] = reactive_power_b
 
             inductive_kvarh_b = u32(46)          # 46~47
-            self.data["inductive_kvarh_b"] = round(inductive_kvarh_b / 800, 3)
+            self.data["inductive_kvarh_b"] = round(inductive_kvarh_b / 1000, 3)
 
             capacitive_kvarh_b = u32(48)         # 48~49
-            self.data["capacitive_kvarh_b"] = round(capacitive_kvarh_b / 800, 3)
+            self.data["capacitive_kvarh_b"] = round(capacitive_kvarh_b / 1000, 3)
 
             reactive_power_c = s32(50)           # 50~51
             self.data["reactive_power_c"] = reactive_power_c
 
             inductive_kvarh_c = u32(52)          # 52~53
-            self.data["inductive_kvarh_c"] = round(inductive_kvarh_c / 800, 3)
+            self.data["inductive_kvarh_c"] = round(inductive_kvarh_c / 1000, 3)
 
             capacitive_kvarh_c = u32(54)         # 54~55
-            self.data["capacitive_kvarh_c"] = round(capacitive_kvarh_c / 800, 3)
+            self.data["capacitive_kvarh_c"] = round(capacitive_kvarh_c / 1000, 3)
 
             # Runtime at address 64
             runtime = u32(64)                    # 64~65

--- a/custom_components/iammeter_modbus/__init__.py
+++ b/custom_components/iammeter_modbus/__init__.py
@@ -190,7 +190,7 @@ class IammeterModbusHub:
 
     def read_modbus_holding_registers(self):
         """Read modbus holding registers with error handling and modern API."""
-        typeCount = 38
+        typeCount = 66  # Extended to include all registers up to runtime at 64-65
         if self._type == TYPE_3080:
             typeCount = 8
 
@@ -331,5 +331,37 @@ class IammeterModbusHub:
             total_export_energy = u32(36)       # 36~37
             self.data["total_export_energy"] = round(
                 total_export_energy * 0.00125, 2)
+
+            # Reactive power readings
+            reactive_power_a = s32(38)           # 38~39
+            self.data["reactive_power_a"] = reactive_power_a
+
+            inductive_kvarh_a = u32(40)          # 40~41
+            self.data["inductive_kvarh_a"] = round(inductive_kvarh_a / 800, 3)
+
+            capacitive_kvarh_a = u32(42)         # 42~43
+            self.data["capacitive_kvarh_a"] = round(capacitive_kvarh_a / 800, 3)
+
+            reactive_power_b = s32(44)           # 44~45
+            self.data["reactive_power_b"] = reactive_power_b
+
+            inductive_kvarh_b = u32(46)          # 46~47
+            self.data["inductive_kvarh_b"] = round(inductive_kvarh_b / 800, 3)
+
+            capacitive_kvarh_b = u32(48)         # 48~49
+            self.data["capacitive_kvarh_b"] = round(capacitive_kvarh_b / 800, 3)
+
+            reactive_power_c = s32(50)           # 50~51
+            self.data["reactive_power_c"] = reactive_power_c
+
+            inductive_kvarh_c = u32(52)          # 52~53
+            self.data["inductive_kvarh_c"] = round(inductive_kvarh_c / 800, 3)
+
+            capacitive_kvarh_c = u32(54)         # 54~55
+            self.data["capacitive_kvarh_c"] = round(capacitive_kvarh_c / 800, 3)
+
+            # Runtime at address 64
+            runtime = u32(64)                    # 64~65
+            self.data["runtime"] = runtime
 
             return True

--- a/custom_components/iammeter_modbus/const.py
+++ b/custom_components/iammeter_modbus/const.py
@@ -178,6 +178,70 @@ SENSOR_TYPES: dict[str, list[IamMeterModbusSensorEntityDescription]] = {
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
+	"reactive_power_a": IamMeterModbusSensorEntityDescription(
+		name="Reactive Power A",
+		key="reactive_power_a",
+		native_unit_of_measurement="var",
+        device_class=SensorDeviceClass.REACTIVE_POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+	"reactive_power_b": IamMeterModbusSensorEntityDescription(
+		name="Reactive Power B",
+		key="reactive_power_b",
+		native_unit_of_measurement="var",
+        device_class=SensorDeviceClass.REACTIVE_POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+	"reactive_power_c": IamMeterModbusSensorEntityDescription(
+		name="Reactive Power C",
+		key="reactive_power_c",
+		native_unit_of_measurement="var",
+        device_class=SensorDeviceClass.REACTIVE_POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+	"inductive_kvarh_a": IamMeterModbusSensorEntityDescription(
+		name="Inductive KVARH A",
+		key="inductive_kvarh_a",
+		native_unit_of_measurement="kvarh",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
+	"capacitive_kvarh_a": IamMeterModbusSensorEntityDescription(
+		name="Capacitive KVARH A",
+		key="capacitive_kvarh_a",
+		native_unit_of_measurement="kvarh",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
+	"inductive_kvarh_b": IamMeterModbusSensorEntityDescription(
+		name="Inductive KVARH B",
+		key="inductive_kvarh_b",
+		native_unit_of_measurement="kvarh",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
+	"capacitive_kvarh_b": IamMeterModbusSensorEntityDescription(
+		name="Capacitive KVARH B",
+		key="capacitive_kvarh_b",
+		native_unit_of_measurement="kvarh",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
+	"inductive_kvarh_c": IamMeterModbusSensorEntityDescription(
+		name="Inductive KVARH C",
+		key="inductive_kvarh_c",
+		native_unit_of_measurement="kvarh",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
+	"capacitive_kvarh_c": IamMeterModbusSensorEntityDescription(
+		name="Capacitive KVARH C",
+		key="capacitive_kvarh_c",
+		native_unit_of_measurement="kvarh",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
+	"runtime": IamMeterModbusSensorEntityDescription(
+		name="Runtime",
+		key="runtime",
+		native_unit_of_measurement="s",
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
 }
 
 SENSOR_TYPES_3080: dict[str, list[IamMeterModbusSensorEntityDescription]] = {

--- a/custom_components/iammeter_modbus/const.py
+++ b/custom_components/iammeter_modbus/const.py
@@ -13,6 +13,9 @@ from homeassistant.const import (
     UnitOfEnergy,
     UnitOfFrequency,
     UnitOfPower,
+    UnitOfReactivePower,
+	UnitOfReactiveEnergy,
+    UnitOfTime,
 )
 
 TYPE_3080 = "WEM3080"
@@ -36,12 +39,14 @@ SENSOR_TYPES: dict[str, list[IamMeterModbusSensorEntityDescription]] = {
     	key="voltage_a",
     	native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
 	"current_a": IamMeterModbusSensorEntityDescription(
 		name="Current A",
 		key="current_a",
 		native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
 	),
 	"power_a": IamMeterModbusSensorEntityDescription(
     	name="Power A",
@@ -67,21 +72,23 @@ SENSOR_TYPES: dict[str, list[IamMeterModbusSensorEntityDescription]] = {
 	"power_factor_a": IamMeterModbusSensorEntityDescription(
 		name="Power Factor A",
 		key="power_factor_a",
-    	native_unit_of_measurement=PERCENTAGE,
-		
+    	native_unit_of_measurement=None,
         device_class=SensorDeviceClass.POWER_FACTOR,
+        state_class=SensorStateClass.MEASUREMENT,
 	),
 	"voltage_b": IamMeterModbusSensorEntityDescription(
     	name="Voltage B",
     	key="voltage_b",
     	native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
 	"current_b": IamMeterModbusSensorEntityDescription(
 		name="Current B",
 		key="current_b",
 		native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
 	),
 	"power_b": IamMeterModbusSensorEntityDescription(
     	name="Power B",
@@ -107,9 +114,9 @@ SENSOR_TYPES: dict[str, list[IamMeterModbusSensorEntityDescription]] = {
 	"power_factor_b": IamMeterModbusSensorEntityDescription(
 		name="Power Factor B",
 		key="power_factor_b",
-    	native_unit_of_measurement=PERCENTAGE,
-		
+    	native_unit_of_measurement=None,
         device_class=SensorDeviceClass.POWER_FACTOR,
+        state_class=SensorStateClass.MEASUREMENT,
 	),
 
 	"voltage_c": IamMeterModbusSensorEntityDescription(
@@ -117,12 +124,14 @@ SENSOR_TYPES: dict[str, list[IamMeterModbusSensorEntityDescription]] = {
     	key="voltage_c",
     	native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
 	"current_c": IamMeterModbusSensorEntityDescription(
 		name="Current C",
 		key="current_c",
 		native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
 	),
 	"power_c": IamMeterModbusSensorEntityDescription(
     	name="Power C",
@@ -148,14 +157,16 @@ SENSOR_TYPES: dict[str, list[IamMeterModbusSensorEntityDescription]] = {
 	"power_factor_c": IamMeterModbusSensorEntityDescription(
 		name="Power Factor C",
 		key="power_factor_c",
-    	native_unit_of_measurement=PERCENTAGE,
-		
+    	native_unit_of_measurement=None,
         device_class=SensorDeviceClass.POWER_FACTOR,
+        state_class=SensorStateClass.MEASUREMENT,
 	),
 	"frequency": IamMeterModbusSensorEntityDescription(
     	name="Frequency",
     	key="frequency",
     	native_unit_of_measurement=UnitOfFrequency.HERTZ,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.FREQUENCY,
     ),
 	"total_power": IamMeterModbusSensorEntityDescription(
     	name="Total Power",
@@ -181,64 +192,70 @@ SENSOR_TYPES: dict[str, list[IamMeterModbusSensorEntityDescription]] = {
 	"reactive_power_a": IamMeterModbusSensorEntityDescription(
 		name="Reactive Power A",
 		key="reactive_power_a",
-		native_unit_of_measurement="var",
+		native_unit_of_measurement=UnitOfReactivePower.VOLT_AMPERE_REACTIVE,
         device_class=SensorDeviceClass.REACTIVE_POWER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
 	"reactive_power_b": IamMeterModbusSensorEntityDescription(
 		name="Reactive Power B",
 		key="reactive_power_b",
-		native_unit_of_measurement="var",
+		native_unit_of_measurement=UnitOfReactivePower.VOLT_AMPERE_REACTIVE,
         device_class=SensorDeviceClass.REACTIVE_POWER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
 	"reactive_power_c": IamMeterModbusSensorEntityDescription(
 		name="Reactive Power C",
 		key="reactive_power_c",
-		native_unit_of_measurement="var",
+		native_unit_of_measurement=UnitOfReactivePower.VOLT_AMPERE_REACTIVE,
         device_class=SensorDeviceClass.REACTIVE_POWER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
 	"inductive_kvarh_a": IamMeterModbusSensorEntityDescription(
 		name="Inductive KVARH A",
 		key="inductive_kvarh_a",
-		native_unit_of_measurement="kvarh",
+		native_unit_of_measurement=UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR,
+        device_class=SensorDeviceClass.REACTIVE_ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
 	"capacitive_kvarh_a": IamMeterModbusSensorEntityDescription(
 		name="Capacitive KVARH A",
 		key="capacitive_kvarh_a",
-		native_unit_of_measurement="kvarh",
+		native_unit_of_measurement=UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR,
+        device_class=SensorDeviceClass.REACTIVE_ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
 	"inductive_kvarh_b": IamMeterModbusSensorEntityDescription(
 		name="Inductive KVARH B",
 		key="inductive_kvarh_b",
-		native_unit_of_measurement="kvarh",
+		native_unit_of_measurement=UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR,
+        device_class=SensorDeviceClass.REACTIVE_ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
 	"capacitive_kvarh_b": IamMeterModbusSensorEntityDescription(
 		name="Capacitive KVARH B",
 		key="capacitive_kvarh_b",
-		native_unit_of_measurement="kvarh",
+		native_unit_of_measurement=UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR,
+        device_class=SensorDeviceClass.REACTIVE_ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
 	"inductive_kvarh_c": IamMeterModbusSensorEntityDescription(
 		name="Inductive KVARH C",
 		key="inductive_kvarh_c",
-		native_unit_of_measurement="kvarh",
+		native_unit_of_measurement=UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR,
+        device_class=SensorDeviceClass.REACTIVE_ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
 	"capacitive_kvarh_c": IamMeterModbusSensorEntityDescription(
 		name="Capacitive KVARH C",
 		key="capacitive_kvarh_c",
-		native_unit_of_measurement="kvarh",
+		native_unit_of_measurement=UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR,
+        device_class=SensorDeviceClass.REACTIVE_ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
 	"runtime": IamMeterModbusSensorEntityDescription(
 		name="Runtime",
 		key="runtime",
-		native_unit_of_measurement="s",
+		native_unit_of_measurement=UnitOfTime.SECONDS,
         device_class=SensorDeviceClass.DURATION,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
@@ -250,12 +267,14 @@ SENSOR_TYPES_3080: dict[str, list[IamMeterModbusSensorEntityDescription]] = {
     	key="voltage_a",
     	native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
 	"current_a": IamMeterModbusSensorEntityDescription(
 		name="Current",
 		key="current_a",
 		native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
 	),
 	"power_a": IamMeterModbusSensorEntityDescription(
     	name="Power",


### PR DESCRIPTION
Update to support [IAMMETER's modbus table](https://www.iammeter.com/newsshow/blog-modbus-rtu-20240617) and Runtime parameter from [latest update](https://www.iammeter.com/newsshow/firmware-upgrade-202509)

 - Add reactive power sensors for all three phases (VAR)
  - Add inductive and capacitive KVARH sensors for all phases
  - Add runtime sensor to track device uptime
  - Extend Modbus register reading from 38 to 66 registers
  - Fix duplicate code in register reading logic
  - All new sensors follow Home Assistant best practices with proper device classes